### PR TITLE
Add total price placeholder

### DIFF
--- a/app/api/model-prices/route.ts
+++ b/app/api/model-prices/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+const MODEL_PRICES_URL = 'https://raw.githubusercontent.com/BerriAI/litellm/refs/heads/main/model_prices_and_context_window.json';
+
+export async function GET() {
+  const res = await fetch(MODEL_PRICES_URL, { next: { revalidate: 86400 } });
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/app/api/openai/route.ts
+++ b/app/api/openai/route.ts
@@ -77,7 +77,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       response: data.choices[0].message.content,
-      tokens: data.usage.total_tokens,
+      promptTokens: data.usage.prompt_tokens,
+      completionTokens: data.usage.completion_tokens,
+      totalTokens: data.usage.total_tokens,
     });
 
   } catch (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,11 @@ interface ModelResult {
   model: string;
   response: string;
   tokens: number;
+  promptTokens: number;
+  completionTokens: number;
+  price: number;
+  inputPrice: number;
+  outputPrice: number;
   responseTime: number;
   error?: string;
 }
@@ -128,6 +133,10 @@ export default function Home() {
   const [customModels, setCustomModels] = useState<string[]>(DEFAULT_MODELS);
   const [tempModelsText, setTempModelsText] = useState('');
   const [advancedSettings, setAdvancedSettings] = useState<AdvancedSettings>(DEFAULT_ADVANCED_SETTINGS);
+  const [modelPrices, setModelPrices] = useState<Record<string, any>>({});
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [totalInputPrice, setTotalInputPrice] = useState(0);
+  const [totalOutputPrice, setTotalOutputPrice] = useState(0);
   
   const [modelStates, setModelStates] = useState<Record<string, ModelState>>(() => {
     const initialStates: Record<string, ModelState> = {};
@@ -180,6 +189,20 @@ export default function Home() {
         console.error('Failed to parse saved advanced settings:', error);
       }
     }
+  }, []);
+
+  // Fetch model prices once on mount
+  useEffect(() => {
+    const loadPrices = async () => {
+      try {
+        const res = await fetch('/api/model-prices');
+        const data = await res.json();
+        setModelPrices(data);
+      } catch (e) {
+        console.error('Failed to load model prices', e);
+      }
+    };
+    loadPrices();
   }, []);
 
   // Save advanced settings to localStorage whenever they change
@@ -294,6 +317,12 @@ export default function Home() {
     if (enabledModels.length === 0) return;
 
     setIsRunning(true);
+    setTotalPrice(0);
+    setTotalInputPrice(0);
+    setTotalOutputPrice(0);
+    let runTotalPrice = 0;
+    let runInputPrice = 0;
+    let runOutputPrice = 0;
 
     // Initialize loading states
     const newStates = { ...modelStates };
@@ -343,6 +372,17 @@ export default function Home() {
         const responseTime = (endTime - newStates[model].startTime) / 1000;
 
         if (response.ok) {
+          const priceInfo = modelPrices[model];
+          const inputPrice = priceInfo
+            ? data.promptTokens * priceInfo.input_cost_per_token
+            : 0;
+          const outputPrice = priceInfo
+            ? data.completionTokens * priceInfo.output_cost_per_token
+            : 0;
+          const price = inputPrice + outputPrice;
+          runTotalPrice += price;
+          runInputPrice += inputPrice;
+          runOutputPrice += outputPrice;
           setModelStates(prev => ({
             ...prev,
             [model]: {
@@ -351,7 +391,12 @@ export default function Home() {
               result: {
                 model,
                 response: data.response,
-                tokens: data.tokens,
+                tokens: data.totalTokens,
+                promptTokens: data.promptTokens,
+                completionTokens: data.completionTokens,
+                price,
+                inputPrice,
+                outputPrice,
                 responseTime
               }
             }
@@ -373,6 +418,11 @@ export default function Home() {
                 model,
                 response: '',
                 tokens: 0,
+                promptTokens: 0,
+                completionTokens: 0,
+                price: 0,
+                inputPrice: 0,
+                outputPrice: 0,
                 responseTime,
                 error: errorMessage
               }
@@ -398,6 +448,11 @@ export default function Home() {
               model,
               response: '',
               tokens: 0,
+              promptTokens: 0,
+              completionTokens: 0,
+              price: 0,
+              inputPrice: 0,
+              outputPrice: 0,
               responseTime,
               error: errorMessage
             }
@@ -407,6 +462,9 @@ export default function Home() {
     });
 
     await Promise.all(promises);
+    setTotalPrice(runTotalPrice);
+    setTotalInputPrice(runInputPrice);
+    setTotalOutputPrice(runOutputPrice);
     setIsRunning(false);
   };
 
@@ -588,6 +646,12 @@ export default function Home() {
                 </div>
               </div>
             </CardContent>
+            <div className="px-6 pb-4 text-sm text-muted-foreground">
+              Total price:{' '}
+              {totalPrice > 0
+                ? `$${totalPrice.toFixed(6)} (input $${totalInputPrice.toFixed(6)} + output $${totalOutputPrice.toFixed(6)})`
+                : 'Run your prompt to evaluate the total cost'}
+            </div>
           </Card>
         </section>
 
@@ -791,6 +855,7 @@ export default function Home() {
                             </div>
                             <div className="flex justify-between text-xs text-muted-foreground pt-2 border-t">
                               <span>{state.result.tokens} tokens</span>
+                              <span>${state.result.price.toFixed(6)}</span>
                               <span>{state.result.responseTime.toFixed(2)}s</span>
                             </div>
                           </>


### PR DESCRIPTION
## Summary
- fetch model prices via `/api/model-prices`
- return token usage numbers in the OpenAI proxy
- compute run pricing and show it per model and for the run
- always show the total price line with a placeholder message when no run data is available

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb4d32294832485b3a2e9723d2240